### PR TITLE
Fix parentheses to brackets in user ns declaration.

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -2,11 +2,11 @@
 
 (ns user
   (:require
-   [clojure.pprint :refer (pprint)]
+   [clojure.pprint :refer [pprint]]
    [clojure.test :refer [run-all-tests]]
-   [clojure.reflect :refer (reflect)]
-   [clojure.repl :refer (apropos dir doc find-doc pst source)]
-   [clojure.tools.namespace.repl :refer (refresh refresh-all)]
+   [clojure.reflect :refer [reflect]]
+   [clojure.repl :refer [apropos dir doc find-doc pst source]]
+   [clojure.tools.namespace.repl :refer [refresh refresh-all]]
    [clojure.java.io :as io]
    [com.stuartsierra.component :as component]
    [clojure.core.async :as a :refer [>! <! >!! <!! chan buffer dropping-buffer sliding-buffer close! timeout alts! alts!! go-loop]]


### PR DESCRIPTION
A couple of the require statements have parentheses instead of brackets for the refer items.