### PR TITLE
Allow the WebServer component to be restarted

### DIFF
--- a/src/edge/web_server.clj
+++ b/src/edge/web_server.clj
@@ -98,7 +98,7 @@
   (stop [component]
     (when-let [close (get-in component [:listener :close])]
       (close))
-    (dissoc component :listener)))
+    (assoc component :listener nil)))
 
 (defn new-web-server []
   (using


### PR DESCRIPTION
`Dissoc`-ing one of the defined fields of a record returns a regular Clojure map instead of a record instance. Due to this the WebServer cannot be started again once it is stopped. Setting the field to `nil` preserves the type.