### PR TITLE
Fix for SPA phone-app react nesting warning

### DIFF
--- a/src/edge/phonebook_app.cljs
+++ b/src/edge/phonebook_app.cljs
@@ -66,25 +66,24 @@
     (let [state @app-state]
       [:div
        [:p "Select any of the entries in this table to reveal a form below."]
-       [:p
-        [:table
-         [:thead
-          [:tr {:on-click (fn [_] (swap! app-state dissoc :current))}
-           [:th "Id"]
-           [:th "Firstname"]
-           [:th "Surname"]
-           [:th "Phone"]]]
-         [:tbody
-          (for [[id {:keys [firstname surname phone]}] (:phonebook state)]
-            ^{:key (keyword "index" id)}
-            [:tr {:on-click (fn [_] (swap! app-state assoc :current [id (get (:phonebook state) id)]))
-                  :class (if (= id (-> state :current first)) "selected" "")
-                  }
-             [:td id]
-             [:td firstname]
-             [:td surname]
-             [:td phone]]
-            )]]]
+       [:table
+        [:thead
+         [:tr {:on-click (fn [_] (swap! app-state dissoc :current))}
+          [:th "Id"]
+          [:th "Firstname"]
+          [:th "Surname"]
+          [:th "Phone"]]]
+        [:tbody
+         (for [[id {:keys [firstname surname phone]}] (:phonebook state)]
+           ^{:key (keyword "index" id)}
+           [:tr {:on-click (fn [_] (swap! app-state assoc :current [id (get (:phonebook state) id)]))
+                 :class (if (= id (-> state :current first)) "selected" "")
+                 }
+            [:td id]
+            [:td firstname]
+            [:td surname]
+            [:td phone]]
+           )]]
 
        (when-let [[id entry] (:current state)]
          [:div.container


### PR DESCRIPTION
I investigated SPA phone application (master) internals in chrome and saw red warning in console: 

> ```
react.inc.js:19500 Warning: validateDOMNesting(...): <table> cannot appear as a descendant of <p>. See edge.phonebook_app.phonebook > p >... > table.
```

Removing wrapping `<p>` element fixes it. It could be connected to [HTML nesting rules](https://www.w3.org/TR/html401/struct/text.html#h-9.3.1).

If you find this PR worth including please do so.