### PR TITLE
Use auto-generated ALB DNS as the host-name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pom.xml.asc
 /terraform.tfstate
 /terraform.tfstate.backup
 /.terraform.tfstate.lock.info
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM java:8
-MAINTAINER JUXT <info@juxt.pro>
-
-ADD target/edge-app.jar /srv/edge-app.jar
-ADD target /target
-
-EXPOSE 3080
-
-CMD ["java", "-jar", "/srv/edge-app.jar"]

--- a/Machfile.edn
+++ b/Machfile.edn
@@ -1,5 +1,5 @@
 {mach/m2 [[aero "1.1.2"]
-          [roll "0.0.6"]]
+          [roll "0.0.7-SNAPSHOT"]]
 
  mach/props [config (:deployment (aero.core/read-config "resources/config.edn" {:profile :prod}))
              version (roll.core/git-version)
@@ -24,5 +24,20 @@
          novelty (mach.core/modified-since product ["Machfile.edn" "resources/config.edn"])
          produce (-> config
                      (roll.core/preprocess)
+
+                     ;; Bidi/Yada in Edge requires a host-name for the
+                     ;; vhosts configuration as is best practice. In
+                     ;; order to get Edge running/deployment into AWS
+                     ;; without needing a pre-setup host-name, we set
+                     ;; an environmental variable into the launch
+                     ;; configuration that matches the DNS of the
+                     ;; load-balancer DNS that is auto-assigned by
+                     ;; AWS. Note that the recommended approach is to
+                     ;; configure `:route-53-aliases` in the Roll
+                     ;; config, which requires a route-53 zone-id you
+                     ;; must manually configure.
+                     (assoc-in [:services :edge :launch-config :args :env-vars :edge-host]
+                               (roll.utils/ref-var [:aws-alb :edge :dns-name]))
+
                      (roll.core/deployment->tf)
                      (roll.core/->tf-json))}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -5,8 +5,14 @@
 {:web-server
  #profile {:dev {:host "localhost:3000"
                  :port 3000}
-           :prod {:host "edge.juxt.cloud"
-                  :port  3080}}
+           :prod {;; We use an environment variable so that the host
+                  ;; can be passed in at runtime. Note, it's best
+                  ;; practice to use a pre-configured host-name,
+                  ;; i.e. edge.juxt.cloud. Roll can assist in the
+                  ;; configuration of route-53 host-names and
+                  ;; assignment to load-balancers.
+                  :host #env EDGE_HOST
+                  :port 3080}}
 
  :selmer
  {:template-caching?
@@ -41,9 +47,10 @@
                                        :forward ^:ref [:web-server :port]
                                        :protocol "HTTP"}]}
 
-              :route-53-aliases [{:name-prefix ^:ref [:web-server :host]
-                                  :zone-id "Z1JI8NSPH3VZUO"
-                                  :load-balancer :edge}]
+              ;; Recommended - setup a route-53 host-name prefix using
+              ;; a manually pre-configured zone-id:
+              ;; :route-53-aliases [{:name-prefix ^:ref [:web-server :host] :zone-id
+              ;;                     "Z1JI8NSPH3VZUO" :load-balancer :edge}]
 
               :services {:edge {:ami "ami-785db401"
                                 :instance-type "m3.medium"

--- a/src/edge/web_server.clj
+++ b/src/edge/web_server.clj
@@ -114,7 +114,7 @@
       component                         ; idempotence
       (let [vhosts-model (vhosts-model [{:scheme :http :host host} (routes db {:port port})])
             listener (yada/listener vhosts-model {:port port})]
-        (infof "Started web-server on port %s" (:port listener))
+        (infof "Started web-server on port %s host %s" (:port listener) host)
         (assoc component :listener listener))))
 
   (stop [component]


### PR DESCRIPTION
This lowers the barrier to entry. Currently users are required to setup a route-53 hosted zone before they can use the Roll deployment mechanism.

Note - this PR isn't ready for merge. We need to add some info to the README that describes the deployment process, and steps for upgrading to using a hosted-zone, which is the preferred approach.

This PR depends on the very latest Roll version - I've deployed a snapshot 0.0.7.