### PR TITLE
Cljfmt Style Checking

### DIFF
--- a/app/aliases/krei/load_krei.clj
+++ b/app/aliases/krei/load_krei.clj
@@ -1,6 +1,6 @@
 (ns ^{:clojure.tools.namespace.repl/load false}
-  load-krei
+ load-krei
   (:require
-    [io.dominic.krei.alpha.core :as krei]))
+   [io.dominic.krei.alpha.core :as krei]))
 
 (def krei (krei/watch))

--- a/app/aliases/nrepl/nrepl.clj
+++ b/app/aliases/nrepl/nrepl.clj
@@ -10,12 +10,12 @@
   [opts]
   (let [server
         (nrepl.server/start-server
-          :port (:port opts)
-          :handler
-          (apply nrepl.server/default-handler
-                 (conj (map #'cider.nrepl/resolve-or-fail cider.nrepl/cider-middleware)
-                       #'refactor.nrepl/wrap-refactor
-                       #'cemerick.piggieback/wrap-cljs-repl)))]
+         :port (:port opts)
+         :handler
+         (apply nrepl.server/default-handler
+                (conj (map #'cider.nrepl/resolve-or-fail cider.nrepl/cider-middleware)
+                      #'refactor.nrepl/wrap-refactor
+                      #'cemerick.piggieback/wrap-cljs-repl)))]
     (spit ".nrepl-port" (:port server))
     (println (io.aviso.ansi/yellow (str "[Edge] nREPL client can be connected to port " (:port server))))
     server))

--- a/app/aliases/rebel/edge/rebel/main.clj
+++ b/app/aliases/rebel/edge/rebel/main.clj
@@ -1,20 +1,20 @@
 (ns edge.rebel.main
   (:require
-    rebel-readline.clojure.main
-    rebel-readline.core
-    io.aviso.ansi))
+   rebel-readline.clojure.main
+   rebel-readline.core
+   io.aviso.ansi))
 
 (defn -main
   [& args]
   (rebel-readline.core/ensure-terminal
-    (rebel-readline.clojure.main/repl
-      :init (fn []
-              (try
-                (println "[Edge] Loading Clojure code, please wait...")
-                (require 'dev)
-                (in-ns 'dev)
-                (println (io.aviso.ansi/bold-yellow "[Edge] Now enter (go) to start the dev system"))
-                (catch Exception e
-                  (.printStackTrace e)
-                  (println "[Edge] Failed to require dev, this usually means there was a syntax error. See exception above.")
-                  (println "[Edge] Please correct it, and enter (fixed!) to resume development.")))))))
+   (rebel-readline.clojure.main/repl
+    :init (fn []
+            (try
+              (println "[Edge] Loading Clojure code, please wait...")
+              (require 'dev)
+              (in-ns 'dev)
+              (println (io.aviso.ansi/bold-yellow "[Edge] Now enter (go) to start the dev system"))
+              (catch Exception e
+                (.printStackTrace e)
+                (println "[Edge] Failed to require dev, this usually means there was a syntax error. See exception above.")
+                (println "[Edge] Please correct it, and enter (fixed!) to resume development.")))))))

--- a/app/bin/lint
+++ b/app/bin/lint
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+clojure -A:lint -d aliases -d dev

--- a/app/bin/lint
+++ b/app/bin/lint
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-clojure -A:lint -d aliases -d dev
+clojure -A:lint

--- a/app/bin/lint-fix
+++ b/app/bin/lint-fix
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-clojure -A:lint:lint/fix -d aliases -d dev
+clojure -A:lint:lint/fix

--- a/app/bin/lint-fix
+++ b/app/bin/lint-fix
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+clojure -A:lint:lint/fix -d aliases -d dev

--- a/app/cljfmt.edn
+++ b/app/cljfmt.edn
@@ -1,0 +1,3 @@
+{
+ ;; src and test are included by default
+ :dirs ["aliases" "dev"]}

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -32,6 +32,10 @@
   ch.qos.logback/logback-classic {:mvn/version "1.2.3"
                                   :exclusions [org.slf4j/slf4j-api]}}
 
+ :cljfmt {
+          ;; src and test are included by default
+          :dirs ["aliases" "dev"]}
+
  :aliases
  {:dev
   {:extra-paths ["dev" "test"]
@@ -58,7 +62,7 @@
 
   :lint {:extra-deps {com.jameslaverack/cljfmt-runner
                       {:git/url "https://github.com/JamesLaverack/cljfmt-runner"
-                       :sha "89ce40d0688532f67ce45fe02f98c2771c8a7611"}}
+                       :sha "50b12955a5890135a228b17c8b663fa05ce8f732"}}
          :main-opts ["-m" "cljfmt-runner.check"]}
   :lint/fix {:main-opts ["-m" "cljfmt-runner.fix"]}
 

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -32,10 +32,6 @@
   ch.qos.logback/logback-classic {:mvn/version "1.2.3"
                                   :exclusions [org.slf4j/slf4j-api]}}
 
- :cljfmt {
-          ;; src and test are included by default
-          :dirs ["aliases" "dev"]}
-
  :aliases
  {:dev
   {:extra-paths ["dev" "test"]
@@ -62,7 +58,7 @@
 
   :lint {:extra-deps {com.jameslaverack/cljfmt-runner
                       {:git/url "https://github.com/JamesLaverack/cljfmt-runner"
-                       :sha "50b12955a5890135a228b17c8b663fa05ce8f732"}}
+                       :sha "0a9c27decb7bad61158ec0f7100dd8da4e43081b"}}
          :main-opts ["-m" "cljfmt-runner.check"]}
   :lint/fix {:main-opts ["-m" "cljfmt-runner.fix"]}
 

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -56,6 +56,12 @@
            :sha "5fb4fc46ad0bf2e0ce45eba5b9117a2e89166479"}}
          :main-opts ["-m" "cognitect.test-runner"]}
 
+  :lint {:extra-deps {com.jameslaverack/cljfmt-runner
+                      {:git/url "https://github.com/JamesLaverack/cljfmt-runner"
+                       :sha "89ce40d0688532f67ce45fe02f98c2771c8a7611"}}
+         :main-opts ["-m" "cljfmt-runner.check"]}
+  :lint/fix {:main-opts ["-m" "cljfmt-runner.fix"]}
+
   :dev/rebel {:extra-paths ["aliases/rebel"]
               :extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.1"}}
               :main-opts ["-m" "edge.rebel.main"]}

--- a/app/dev/dev.clj
+++ b/app/dev/dev.clj
@@ -23,8 +23,8 @@
 (defn go []
   (let [res (integrant.repl/go)]
     (println (io.aviso.ansi/yellow
-               (format "[Edge] Website can be browsed at http://%s/"
-                       (-> system :edge/httpd :host))))
+              (format "[Edge] Website can be browsed at http://%s/"
+                      (-> system :edge/httpd :host))))
     (println (io.aviso.ansi/bold-yellow "[Edge] Now make code changes, then enter (reset) here"))
     res))
 
@@ -41,22 +41,21 @@
   "Start a ClojureScript REPL"
   []
   (eval
-    `(do
-       (require 'figwheel-sidecar.repl-api)
-       (figwheel-sidecar.repl-api/cljs-repl))))
-
+   `(do
+      (require 'figwheel-sidecar.repl-api)
+      (figwheel-sidecar.repl-api/cljs-repl))))
 
 ;; REPL Convenience helpers
 (defn graphql [q]
   (edge.yada.lacinia/query
-    (:edge.component/phonebook-db system)
-    (:edge.component/graphql-schema system)
-    q))
+   (:edge.component/phonebook-db system)
+   (:edge.component/graphql-schema system)
+   q))
 
 (defn graphql-stream [q]
   (edge.yada.lacinia/subscription-stream
-    (:edge.component/phonebook-db system)
-    (:edge.component/graphql-schema system)
-    q))
+   (:edge.component/phonebook-db system)
+   (:edge.component/graphql-schema system)
+   q))
 
 ;; (graphql "query { person(id:102) { firstname phone surname }}")

--- a/app/src/edge/examples.clj
+++ b/app/src/edge/examples.clj
@@ -160,8 +160,7 @@
 
 (defn authentication-example-routes []
   ["/authn-examples"
-   [
-    ["/basic" #'basic-auth-resource-example]
+   [["/basic" #'basic-auth-resource-example]
     ["/custom-static" #'custom-auth-static-resource-example]
     ["/custom-trusted-header" #'custom-auth-trusted-header-resource-example]
     ["/custom-signed-header" #'custom-auth-signed-header-resource-example]

--- a/app/src/edge/hello.clj
+++ b/app/src/edge/hello.clj
@@ -32,12 +32,9 @@
      {:get
       {:parameters {:query {:p String}}
        :produces "text/plain"
-       :response (fn [ctx] (format "Hello %s!\n" (-> ctx :parameters :query :p)))
-       }}})])
+       :response (fn [ctx] (format "Hello %s!\n" (-> ctx :parameters :query :p)))}}})])
 
 (defn other-hello-routes []
-  ["" [
-       (hello-language)
+  ["" [(hello-language)
        (hello-atom)
-       (hello-parameter)
-       ]])
+       (hello-parameter)]])

--- a/app/src/edge/httpd.clj
+++ b/app/src/edge/httpd.clj
@@ -24,8 +24,7 @@
 
 (defn content-routes []
   ["/"
-   [
-    ["index.html"
+   [["index.html"
      (yada/resource
       {:id :edge.resources/index
        :methods
@@ -39,7 +38,7 @@
     ["public/" (assoc (new-classpath-resource "public") :id :edge.resources/static)]
 
     ;; Add some pairs (as vectors) here. First item is the path, second is the handler.
-    ]])
+]])
 
 (defn routes
   "Create the URI route structure for our application."
@@ -47,8 +46,7 @@
     :edge/keys [graphql-schema event-bus]
     :as config}]
   [""
-   [
-    ;; Hello World!
+   [;; Hello World!
     (hello-routes)
     (other-hello-routes)
 
@@ -63,10 +61,10 @@
                 ;; provides a swagger.json file, used by Swagger UI
                 ;; and other tools.
                 (yada/swaggered
-                  {:info {:title "Hello World!"
-                          :version "1.0"
-                          :description "An API on the classic example"}
-                   :basePath "/api"})
+                 {:info {:title "Hello World!"
+                         :version "1.0"
+                         :description "An API on the classic example"}
+                  :basePath "/api"})
                 ;; Tag it so we can create an href to this API
                 (tag :edge.resources/api))]
 
@@ -78,52 +76,48 @@
     ;; GraphQL
     ["/graphql"
      (yada/resource
-       {:methods
-        {:post
-         {:consumes "application/json"
-          :produces "application/json"
-          :response (fn [ctx]
-                      (edge.yada.lacinia/query db graphql-schema (-> ctx :body :query)))}}})]
+      {:methods
+       {:post
+        {:consumes "application/json"
+         :produces "application/json"
+         :response (fn [ctx]
+                     (edge.yada.lacinia/query db graphql-schema (-> ctx :body :query)))}}})]
 
     ["/graphql-stream"
      (yada/resource
-       {:methods
-        {:post
-         {:consumes "application/json"
-          :produces "text/event-stream"
-          :response (fn [ctx]
-                      (edge.yada.lacinia/subscription-stream db graphql-schema (-> ctx :body :query)))}}})]
+      {:methods
+       {:post
+        {:consumes "application/json"
+         :produces "text/event-stream"
+         :response (fn [ctx]
+                     (edge.yada.lacinia/subscription-stream db graphql-schema (-> ctx :body :query)))}}})]
 
     #_["/gtest"
-     (fn [req]
-       (let [s (ms/stream)]
-         {:status 200 :body s}))
-     ]
+       (fn [req]
+         (let [s (ms/stream)]
+           {:status 200 :body s}))]
 
     ["/status" (yada/resource
-                 {:methods
-                  {:get
-                   {:produces "text/html"
-                    :response (fn [ctx]
-                                (html
-                                  [:body
-                                   [:div
-                                    [:h2 "System properties"]
-                                    [:table
-                                     (for [[k v] (sort (into {} (System/getProperties)))]
-                                       [:tr
-                                        [:td [:pre k]]
-                                        [:td [:pre v]]]
-                                       )]]
-                                   [:div
-                                    [:h2 "Environment variables"]
-                                    [:table
-                                     (for [[k v] (sort (into {} (System/getenv)))]
-                                       [:tr
-                                        [:td [:pre k]]
-                                        [:td [:pre v]]]
-                                       )]]
-                                   ]))}}})]
+                {:methods
+                 {:get
+                  {:produces "text/html"
+                   :response (fn [ctx]
+                               (html
+                                [:body
+                                 [:div
+                                  [:h2 "System properties"]
+                                  [:table
+                                   (for [[k v] (sort (into {} (System/getProperties)))]
+                                     [:tr
+                                      [:td [:pre k]]
+                                      [:td [:pre v]]])]]
+                                 [:div
+                                  [:h2 "Environment variables"]
+                                  [:table
+                                   (for [[k v] (sort (into {} (System/getenv)))]
+                                     [:tr
+                                      [:td [:pre k]]
+                                      [:td [:pre v]]])]]]))}}})]
 
     ;; The Edge source code is served for convenience
     (source-routes)

--- a/app/src/edge/main.clj
+++ b/app/src/edge/main.clj
@@ -2,8 +2,8 @@
   "Entrypoint for production Uberjars"
   (:gen-class)
   (:require
-    [integrant.core :as ig]
-    [edge.system :refer [new-system]]))
+   [integrant.core :as ig]
+   [edge.system :refer [new-system]]))
 
 (def system nil)
 

--- a/app/src/edge/phonebook.clj
+++ b/app/src/edge/phonebook.clj
@@ -126,28 +126,26 @@
 (defn phonebook-routes [{:edge.phonebook/keys [db]
                          :edge.http/keys [port]}]
   (let [routes ["/phonebook"
-                [
-                 ;; Phonebook index
+                [;; Phonebook index
                  ["" (new-index-resource db)]
                  ;; Phonebook entry, with path parameter
                  [["/" :id] (new-entry-resource db)]]]]
     [""
-     [
-      routes
+     [routes
 
       ;; Swagger
       ["/phonebook-api/swagger.json"
        (bidi/tag
-         (yada/handler
-           (swagger/swagger-spec-resource
-             (swagger/swagger-spec
-               routes
-               {:info {:title "Phonebook"
-                       :version "1.0"
-                       :description "A simple application that demonstrates the use of multiple HTTP methods"}
-                :host (format "localhost:%d" port)
-                :schemes ["http"]
-                :tags [{:name "getters"
-                        :description "All paths that support GET"}]
-                :basePath ""})))
-         :edge.resources/phonebook-swagger)]]]))
+        (yada/handler
+         (swagger/swagger-spec-resource
+          (swagger/swagger-spec
+           routes
+           {:info {:title "Phonebook"
+                   :version "1.0"
+                   :description "A simple application that demonstrates the use of multiple HTTP methods"}
+            :host (format "localhost:%d" port)
+            :schemes ["http"]
+            :tags [{:name "getters"
+                    :description "All paths that support GET"}]
+            :basePath ""})))
+        :edge.resources/phonebook-swagger)]]]))

--- a/app/src/edge/phonebook/db.clj
+++ b/app/src/edge/phonebook/db.clj
@@ -24,15 +24,15 @@
   entry."
   [db id entry]
   (dosync
-    (alter (:phonebook db) assoc id entry))
+   (alter (:phonebook db) assoc id entry))
   (assert (:manifold/event-bus db))
   (publish!
-    (:manifold/event-bus db)
-    :phonebook
-    {:event :entry-updated
-     :id id
-     :value entry
-     :message (format "Phonebook entry %d replaced with %s" id entry)}))
+   (:manifold/event-bus db)
+   :phonebook
+   {:event :entry-updated
+    :id id
+    :value entry
+    :message (format "Phonebook entry %d replaced with %s" id entry)}))
 
 (defn delete-entry
   "Delete a entry from the database."

--- a/app/src/edge/phonebook_app.clj
+++ b/app/src/edge/phonebook_app.clj
@@ -12,13 +12,13 @@
     :edge.httpd/keys [port]}]
   ["/phonebook-app"
    (yada/resource
-     {:id :edge.resources/phonebook-app
-      :methods
-      {:get
-       {:produces "text/html"
-        :response
-        (fn [ctx]
-          (selmer/render-file
-            "phonebook-app.html"
-            {:title "Edge phonebook app"
-             :ctx ctx}))}}})])
+    {:id :edge.resources/phonebook-app
+     :methods
+     {:get
+      {:produces "text/html"
+       :response
+       (fn [ctx]
+         (selmer/render-file
+          "phonebook-app.html"
+          {:title "Edge phonebook app"
+           :ctx ctx}))}}})])

--- a/app/src/edge/phonebook_app.cljs
+++ b/app/src/edge/phonebook_app.cljs
@@ -13,44 +13,44 @@
 (defn get-phonebook-data []
   (println "Loading phonebook data")
   (doto
-      (new js/XMLHttpRequest)
-      (.open "GET" "/phonebook")
-      (.setRequestHeader "Accept" "application/edn")
-      (.addEventListener
-       "load"
-       (fn [evt]
-         (swap! app-state
-                assoc :phonebook
-                (read-string evt.currentTarget.responseText))))
-      (.send)))
+   (new js/XMLHttpRequest)
+    (.open "GET" "/phonebook")
+    (.setRequestHeader "Accept" "application/edn")
+    (.addEventListener
+     "load"
+     (fn [evt]
+       (swap! app-state
+              assoc :phonebook
+              (read-string evt.currentTarget.responseText))))
+    (.send)))
 
 (defn save-entry [state]
   (let [[id entry] (:current state)]
     (println "Saving entry:" id entry)
     (doto
-        (new js/XMLHttpRequest)
-        (.open "PUT" (str "/phonebook/" id))
-        (.setRequestHeader "Content-Type" "application/edn")
-        (.addEventListener
-         "load"
-         (fn [e]
-           (when (<= 200 e.target.status 299)
-             (swap! app-state update :phonebook conj (:current state)))))
-        (.send (pr-str entry)))))
+     (new js/XMLHttpRequest)
+      (.open "PUT" (str "/phonebook/" id))
+      (.setRequestHeader "Content-Type" "application/edn")
+      (.addEventListener
+       "load"
+       (fn [e]
+         (when (<= 200 e.target.status 299)
+           (swap! app-state update :phonebook conj (:current state)))))
+      (.send (pr-str entry)))))
 
 (defn delete-entry [state]
   (let [[id entry] (:current state)]
     (println "Deleting entry:" id entry)
     (doto
-        (new js/XMLHttpRequest)
-        (.open "DELETE" (str "/phonebook/" id))
-        (.addEventListener
-         "load"
-         (fn [e]
-           (when (= e.target.status 200)
-             (swap! app-state update :phonebook dissoc id)
-             (swap! app-state dissoc :current))))
-        (.send))))
+     (new js/XMLHttpRequest)
+      (.open "DELETE" (str "/phonebook/" id))
+      (.addEventListener
+       "load"
+       (fn [e]
+         (when (= e.target.status 200)
+           (swap! app-state update :phonebook dissoc id)
+           (swap! app-state dissoc :current))))
+      (.send))))
 
 (defn needs-saving? [state]
   (when-let [db-entry (get (:phonebook state)
@@ -77,13 +77,11 @@
          (for [[id {:keys [firstname surname phone]}] (:phonebook state)]
            ^{:key (keyword "index" id)}
            [:tr {:on-click (fn [_] (swap! app-state assoc :current [id (get (:phonebook state) id)]))
-                 :class (if (= id (-> state :current first)) "selected" "")
-                 }
+                 :class (if (= id (-> state :current first)) "selected" "")}
             [:td id]
             [:td firstname]
             [:td surname]
-            [:td phone]]
-           )]]
+            [:td phone]])]]
 
        (when-let [[id entry] (:current state)]
          [:div.container

--- a/app/src/edge/sources.clj
+++ b/app/src/edge/sources.clj
@@ -11,8 +11,7 @@
   []
   ["/sources/"
    (yada/resource
-    {
-     ;; We enable path-info which means that the route matches any
+    {;; We enable path-info which means that the route matches any
      ;; path that matches /sources/*.
      :path-info? true
 
@@ -30,8 +29,7 @@
          {:exists? false}))
 
      :methods
-     {:get {
-            ;; Serve as 'raw' (text/plain)
+     {:get {;; Serve as 'raw' (text/plain)
             :produces {:media-type "text/plain"
                        :charset "UTF-8"}
             ;; Return the file we found as the response.

--- a/app/src/edge/yada/lacinia.clj
+++ b/app/src/edge/yada/lacinia.clj
@@ -28,20 +28,20 @@
     (let [cancel (promise)
           source-stream (ms/stream)
           close-fn (com.walmartlabs.lacinia.executor/invoke-streamer
-                     ctx (fn callback [value]
-                           (let [value
-                                 (executor/execute-query
-                                   (assoc ctx ::executor/resolved-value value))]
+                    ctx (fn callback [value]
+                          (let [value
+                                (executor/execute-query
+                                 (assoc ctx ::executor/resolved-value value))]
 
-                             (resolve/on-deliver!
-                               value
-                               (fn [result]
-                                 (println "value delivered is type" (type result))
-                                 (d/chain
-                                   (ms/put! source-stream (pr-str result))
-                                   (fn [put-result]
-                                     (when (false? put-result)
-                                       (deliver cancel :stream-closed)))))))))
+                            (resolve/on-deliver!
+                             value
+                             (fn [result]
+                               (println "value delivered is type" (type result))
+                               (d/chain
+                                (ms/put! source-stream (pr-str result))
+                                (fn [put-result]
+                                  (when (false? put-result)
+                                    (deliver cancel :stream-closed)))))))))
 
           _ (future (do @cancel
                         (debug "Closing source stream")

--- a/app/test/edge/api_test.clj
+++ b/app/test/edge/api_test.clj
@@ -1,6 +1,4 @@
 ;; Copyright © 2016, JUXT LTD.
 
 (ns edge.api-test
-  "Testing the API"
-  
-  )
+  "Testing the API")


### PR DESCRIPTION
Use [cljfmt](https://github.com/weavejester/cljfmt) to check the formatting of all Clojure and Clojurescript files in the project.

The diff on this one is large because of changes to bring the existing code in line with the default style rules. In particular [single space indentation of arguments](https://github.com/bbatsov/clojure-style-guide#one-space-indent).

If you'd rather not have such a large diff, I can rework this to give cljfmt a specific exclusion for that rule to use the two spaces used currently in the code.