### PR TITLE
Fix phonebook swagger-ui "invalid url" exception

### DIFF
--- a/app/src/edge/phonebook.clj
+++ b/app/src/edge/phonebook.clj
@@ -124,7 +124,7 @@
                                    :ctx ctx}))}}}))
 
 (defn phonebook-routes [{:edge.phonebook/keys [db]
-                         :edge.http/keys [port]}]
+                         :edge.httpd/keys [port]}]
   (let [routes ["/phonebook"
                 [
                  ;; Phonebook index


### PR DESCRIPTION
Pressing the "Try it out" button in the swagger ui would result in the following error in the console.

```
index.js:164 Uncaught DOMException: Failed to execute 'open' on 'XMLHttpRequest': Invalid URL
```
This seems to be caused by `port` not being defined as the destructure was trying to access a key that does not exist.