### PR TITLE
Pr meggermo

### DIFF
--- a/main/deps.edn
+++ b/main/deps.edn
@@ -95,7 +95,8 @@
          :main-opts ["-m" "cognitect.test-runner"]}
 
   :dev/rebel {:extra-paths ["aliases/rebel"]
-              :extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.1"}}
+              :extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.1"}
+                           edge.rebel.main {:local/root "../lib.rebel.auto-dev"}}
               :main-opts ["-m" "edge.rebel.main"]}
 
   :dev/cljs {:extra-deps {com.bhauman/rebel-readline-cljs {:mvn/version "0.1.1"}

--- a/main/deps.edn
+++ b/main/deps.edn
@@ -50,7 +50,7 @@
            {:git/url "https://github.com/juxt/kick.alpha.git"
             :sha "eb7ee22efac8f69b2a042980e4736aec5ec352ed"}
            ;; Kick operates a BYOD (bring-your-own-dependency) policy
-           figwheel-sidecar {:mvn/version "0.5.17-SNAPSHOT"
+           figwheel-sidecar {:mvn/version "0.5.18"
                              :exclusions [org.clojure/tools.nrepl]}
            deraen/sass4clj {:mvn/version "0.3.1"}
 
@@ -63,7 +63,7 @@
   :build/once {:main-opts ["-m" "edge.kick"]
                :extra-deps
                {;; Allow figwheel to bring along an nrepl server, because reasons
-                figwheel-sidecar {:mvn/version "0.5.17-SNAPSHOT"}}}
+                figwheel-sidecar {:mvn/version "0.5.18"}}}
 
   :dev/build {:extra-paths ["target/dev"]}
 


### PR DESCRIPTION
Following the [yada manual](https://juxt.pro/yada/manual/index.html) I ran into some issues:

1. According to paragraph 2.1 I should cd into edge/app, but there is no such directory. I figured out it should be edge/main.
2. I tried starting the dev repl as described in 2.2 from the main sub directory but the repl failed to start.

I managed to fix the startup issues, so now the dev repl starts upp and I can successfully access localhost:3000. The commit messages describe what failed and what I did to resolve them.