### PR TITLE
Fix reframe template namespaces and default subs

### DIFF
--- a/lib/edge-app-template/resources/clj/new/app.template/reframe/handlers.cljs
+++ b/lib/edge-app-template/resources/clj/new/app.template/reframe/handlers.cljs
@@ -1,7 +1,7 @@
 (ns {{root-ns}}.frontend.handlers
   (:require
     [re-frame.core :as rf]
-    [{{name}}.db :as db]))
+    [{{root-ns}}.frontend.db :as db]))
 
 ;; -- Handlers --------------------------------------------------------------
 

--- a/lib/edge-app-template/resources/clj/new/app.template/reframe/main.cljs
+++ b/lib/edge-app-template/resources/clj/new/app.template/reframe/main.cljs
@@ -1,8 +1,8 @@
 (ns ^:figwheel-hooks {{root-ns}}.frontend.main
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
-            [{{name}}.views :as views]
-            [{{name}}.handlers :as handlers] ))
+            [{{root-ns}}.frontend.views :as views]
+            [{{root-ns}}.frontend.handlers :as handlers]))
 
 (defn mount-root []
   (when-let [section (.getElementById js/document "app")]

--- a/lib/edge-app-template/resources/clj/new/app.template/reframe/subs.cljs
+++ b/lib/edge-app-template/resources/clj/new/app.template/reframe/subs.cljs
@@ -4,7 +4,7 @@
 (reg-sub
  ::greetings
  (fn [db _]
-   (:greeting db)))
+   (:greetings db)))
 
 (reg-sub
  ::greeting-index

--- a/lib/edge-app-template/resources/clj/new/app.template/reframe/views.cljs
+++ b/lib/edge-app-template/resources/clj/new/app.template/reframe/views.cljs
@@ -1,8 +1,8 @@
 (ns {{root-ns}}.frontend.views
     (:require [reagent.core :as r :refer [atom]]
               [re-frame.core :refer [subscribe dispatch dispatch-sync]]
-              [{{name}}.handlers :as handlers]
-              [{{name}}.subs :as subs]))
+              [{{root-ns}}.frontend.handlers :as handlers]
+              [{{root-ns}}.frontend.subs :as subs]))
 
 (defn main-panel
   []


### PR DESCRIPTION
I noticed that the generated namespaces in the `(:require ...)` weren't correct, when using the `--reframe` flag. I also fixed a small bug in the default reframe code.