### PR TITLE
Rename 'vent' to 'moan' in tutorial.adoc

### DIFF
--- a/doc/resources/doc/sources/tutorial.adoc
+++ b/doc/resources/doc/sources/tutorial.adoc
@@ -1,9 +1,9 @@
 = Tutorial: Creating a twitter clone
 
-We are going to create a new twitter clone called 'moan'.
+We are going to create a new twitter clone called 'vent'.
 
 ----
-cd tutorial.moan
+cd tutorial.vent
 ----
 
 Start a nrepl


### PR DESCRIPTION
This was done in 18ead7e, but it seems the tutorial was not updated.