### PR TITLE
Downgrade cljs version in app template

### DIFF
--- a/lib/edge-app-template/resources/clj/new/app.template/deps.edn
+++ b/lib/edge-app-template/resources/clj/new/app.template/deps.edn
@@ -25,7 +25,7 @@
            juxt/kick.alpha
            {:git/url "https://github.com/juxt/kick.alpha.git"
             :sha "06063beadfa72dfe23480727c347976b608e8316"}{{#cljs}}
-           org.clojure/clojurescript {:mvn/version "1.10.520"}{{#reframe}}
+           org.clojure/clojurescript {:mvn/version "1.10.238"}{{#reframe}}
            reagent {:mvn/version "0.8.1"}
            re-frame {:mvn/version "0.10.6"}{{/reframe}}
            com.bhauman/figwheel-main {:mvn/version "0.2.0"}{{/cljs}}{{#sass}}


### PR DESCRIPTION
1.10.238 is currently the most recent stable version, later versions have issues with figwheel main