### PR TITLE
Update app template style

### DIFF
--- a/lib/edge-app-template/resources/clj/new/app.template/app.css
+++ b/lib/edge-app-template/resources/clj/new/app.template/app.css
@@ -1,7 +1,6 @@
 html, body {
   background-color: #eee;
   height: 100%;
-
   font-family: sans-serif;
 }
 
@@ -10,34 +9,38 @@ html, body {
 }
 
 body {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+    margin: auto;
+}
 
-  margin: 0;
-  padding: 1em;
+nav {
+    margin: 0;
+    background-color: #333333;
+}
+
+h1 {
+    padding: 2rem;
+    margin: auto;
+    color: #f4901d;
 }
 
 .content {
-  background-color: white;
-  padding: 2rem;
-
-  max-width: 960px;
-  width: 50vw;
-
-  margin: auto;
-
-  box-shadow: 0 0 2em rgba(0, 0, 0, 0.4);
-  border-radius: 5px;
-
-  text-align: center;
+    background-color: white;
+    padding: 0 2rem 0 2rem;
+    max-width: 960px;
+    width: 90vw;
+    margin: 2rem auto;
+    border: 1px solid rgba(34, 36, 38, 0.15);
+    border-radius: 5px;
+    box-shadow: inset 0 0 3px rgba(68, 68, 68, 0.2);
+    text-align: center;
 }
 
 #app {
-  box-sizing: border-box;
-  min-height: 50px;
-  width: 100%;
-  background-color: #efefef;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.4);
-  padding: 1em;
+    box-sizing: border-box;
+    min-height: 50px;
+    padding: 1em;
+    width: 100%;
+    background-color: #eee;
+    border-radius: 5px;
+    box-shadow: inset 0 0 3px rgba(68, 68, 68, 0.2);
 }

--- a/lib/edge-app-template/resources/clj/new/app.template/index.html
+++ b/lib/edge-app-template/resources/clj/new/app.template/index.html
@@ -4,17 +4,17 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>{{name}}</title>
-  
     <link rel="stylesheet" href="/{{name}}.css">
   </head>
   <body>
+    <nav>
+      <h1>{{name}}</h1>
+    </nav>
     <div class="content">
-      <div class="content__body">
-        <h1>{{name}}</h1>{{#cljs}}
-        <div id="app">Loading ClojureScript...</div>{{/cljs}}{{^cljs}}
-        <p>Edit this message in <code>src/index.html</code>.</p>{{/cljs}}
-        <p><a href="https://juxt.pro/edge/docs/index.html">Learn Edge</a></p> 
-      </div>
+      <h1>Content</h1>{{#cljs}}
+      <div id="app">Loading ClojureScript...</div>{{/cljs}}{{^cljs}}
+      <p>Edit this message in <code>src/index.html</code>.</p>{{/cljs}}
+      <p><a href="https://juxt.pro/edge/docs/index.html">Learn Edge</a></p>
     </div>{{#cljs}}
     <script src="/frontend.js"></script>{{/cljs}}
   </body>

--- a/lib/edge-app-template/resources/clj/new/app.template/main.cljs
+++ b/lib/edge-app-template/resources/clj/new/app.template/main.cljs
@@ -6,9 +6,9 @@
 (defonce init
   (do (set! (.-innerHTML (js/document.getElementById "app"))
             "<p>Loaded {{name}}!</p>
-            <p>Edit src/{{sanitized}}/frontend/main.cljs to change this message.</p>")
+            <p>Edit <strong><code>src/{{sanitized}}/frontend/main.cljs</code></strong> to change this message.</p>")
       true))
 
 ;; This is called every time you make a code change
 (defn ^:after-load reload []
-  (set! (.-innerText (js/document.getElementById "app")) "Reloaded {{name}}!"))
+  (set! (.-innerText (js/document.getElementById "app")) "Hot Reloaded {{name}}!"))


### PR DESCRIPTION
When a developer starts edge for the first time, they will inevitably see the default template. I think that the latter should serve the purpose of a book cover or a business card in that it should convey values like robustness, code organization, good design, and everything that edge is. For this reason, I feel that having a template that is not just a centered div with some heavy box shadows, suggests that edge is well reasoned, without leaving anything out ... In other words, it just gives the developer a better impression of edge. Of course this comes from my personal experience with edge and you might not share any of those ideas 💡 