### PR TITLE
Update bin/ scripts to pass shellchecking

### DIFF
--- a/bin/app
+++ b/bin/app
@@ -10,7 +10,7 @@ done
 
 for var in "$@"
 do
-  if [ "$var" = "--help" -o  "$var" = "-h" ]; then
+  if [ "$var" = "--help" ] || [ "$var" = "-h" ]; then
     project_name="edge/internal.help"
   fi
 done

--- a/bin/eftest
+++ b/bin/eftest
@@ -22,4 +22,4 @@ while :; do
 done
 
 # Particularly use illegal-access=deny here due to the pretty output of eftest.
-clojure -J--illegal-access=deny "-J-Dlogback.configurationFile=$(dirname $0)/.eftest.logback.xml" $args -Sdeps "$deps" "$(dirname $0)/.eftest.clj" "$@"
+clojure -J--illegal-access=deny "-J-Dlogback.configurationFile=$(dirname "$0")/.eftest.logback.xml" "$args" -Sdeps "$deps" "$(dirname "$0")/.eftest.clj" "$@"

--- a/bin/rebel
+++ b/bin/rebel
@@ -20,7 +20,7 @@ while :; do
         --nrepl)
             nrepl=1
             deps="$deps"' juxt.edge/dev.nrepl {:local/root "../lib/edge.dev.nrepl"}'
-            jvm_opts+='-J-Dedge.load_edge.dev.nrepl=true'
+            jvm_opts+=( '-J-Dedge.load_edge.dev.nrepl=true' )
             shift
             ;;
         --)

--- a/bin/uberjar
+++ b/bin/uberjar
@@ -2,13 +2,14 @@
 
 set -eux
 
-export build_data="$(mktemp -d)"
+build_data="$(mktemp -d)"
+export build_data
 OLDPWD="$PWD"
 
 trap 'rm -rf "$build_data"; cd "$OLDPWD"' EXIT
 
 app="$1"
-dir="$(dirname $0)/../${app}"
+dir="$(dirname "$0")/../${app}"
 
 # Compile sass & clojurescript
 cd "$dir"

--- a/bin/update-edge
+++ b/bin/update-edge
@@ -2,6 +2,6 @@
 
 git pull --no-rebase https://github.com/juxt/edge.git
 
-repo_root="${PWD}/$(dirname $0)/.."
+repo_root="${PWD}/$(dirname "$0")/.."
 
-cd "$(dirname $0)/../lib/edge.migration" && clojure -m edge.migration "$repo_root"
+cd "$(dirname "$0")/../lib/edge.migration" && clojure -m edge.migration "$repo_root"


### PR DESCRIPTION
[SC2155](https://www.shellcheck.net/wiki/SC2155) Declare and assign separately to avoid masking return values.
[SC2166](https://www.shellcheck.net/wiki/SC2166) Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
[SC2179](https://www.shellcheck.net/wiki/SC2179) Use array+=("item") to append items to an array.

I checked bin/uberjar after fixing SC2179, and the output (`set -x`) before and after is the same.