### PR TITLE
Improve bin shell scripts

### DIFF
--- a/bin/eftest
+++ b/bin/eftest
@@ -1,12 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 deps='{:deps {eftest {:mvn/version "0.5.7"} cider/orchard {:mvn/version "0.4.0"}}}'
-args=''
+args=()
 
 while :; do
     case $1 in
         -A*)
-	    args="${args} $1"
+	    args+=("$1")
             shift
             ;;
         --)
@@ -22,4 +22,4 @@ while :; do
 done
 
 # Particularly use illegal-access=deny here due to the pretty output of eftest.
-clojure -J--illegal-access=deny "-J-Dlogback.configurationFile=$(dirname "$0")/.eftest.logback.xml" "$args" -Sdeps "$deps" "$(dirname "$0")/.eftest.clj" "$@"
+clojure -J--illegal-access=deny "-J-Dlogback.configurationFile=$(dirname "$0")/.eftest.logback.xml" "${args[@]}" -Sdeps "$deps" "$(dirname "$0")/.eftest.clj" "$@"

--- a/bin/rebel
+++ b/bin/rebel
@@ -2,8 +2,9 @@
 
 echo "[Edge] Starting development environment, please wait…"
 
-deps='{:deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}
-              juxt.edge/rebel.auto-dev {:local/root "../lib/edge.rebel.auto-dev"}'
+# Dependencies are stored in a Bash array.
+dependencies=( 'com.bhauman/rebel-readline {:mvn/version "0.1.4"}'
+        'juxt.edge/rebel.auto-dev {:local/root "../lib/edge.rebel.auto-dev"}' )
 
 jvm_opts=()
 
@@ -14,12 +15,12 @@ while :; do
     case $1 in
         --cljs)
             cljs=1
-	    deps="$deps"' com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}'
+	        dependencies+=( 'com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}' )
             shift
             ;;
         --nrepl)
             nrepl=1
-            deps="$deps"' juxt.edge/dev.nrepl {:local/root "../lib/edge.dev.nrepl"}'
+            dependencies+=( 'juxt.edge/dev.nrepl {:local/root "../lib/edge.dev.nrepl"}' )
             jvm_opts+=( '-J-Dedge.load_edge.dev.nrepl=true' )
             shift
             ;;
@@ -36,9 +37,10 @@ while :; do
 done
 
 if [ "$cljs" -eq 1 ] && [ "$nrepl" -eq 1 ]; then
-    deps="$deps"' cider/piggieback {:mvn/version "0.4.1"}'
+    dependencies+=( 'cider/piggieback {:mvn/version "0.4.1"}' )
 fi
 
-deps="${deps}}}"
+# Build up the EDN dependency string to pass to `clojure`.
+deps="{:deps { ${dependencies[@]} }}"
 
 clojure "${jvm_opts[@]}" -Sdeps "$deps" "$@" -m edge.rebel.main


### PR DESCRIPTION
In #83 I introduced a bug in the eftest script, this PR fixes that bug
and improves bin/rebel too.

* Fix bug in bin/eftest where arguments were quoted with a leading
  space, i.e. " -A:test" instead of "-A:test". Switch to using Bash
  arrays instead to avoid this issue.
* Use bash arrays in bin/rebel for dynamically adding dependencies