### PR TITLE
Fix bin/eftest when no --junit flag is passed

### DIFF
--- a/bin/.eftest.clj
+++ b/bin/.eftest.clj
@@ -28,7 +28,8 @@
                    eftest.report.progress/report
                    (filter
                      identity
-                     [(report-to-file
-                        (requiring-resolve 'eftest.report.junit/report)
-                        junit-path)]))})]
+                     [(when junit?
+                        (report-to-file
+                          (requiring-resolve 'eftest.report.junit/report)
+                          junit-path))]))})]
   (System/exit (+ (:error summary) (:fail summary))))


### PR DESCRIPTION
This will fail until #85 is fixed.