### PR TITLE
Concatenate deps dependencies with * instead of @

### DIFF
--- a/bin/rebel
+++ b/bin/rebel
@@ -41,6 +41,6 @@ if [ "$cljs" -eq 1 ] && [ "$nrepl" -eq 1 ]; then
 fi
 
 # Build up the EDN dependency string to pass to `clojure`.
-deps="{:deps { ${dependencies[@]} }}"
+deps="{:deps { ${dependencies[*]} }}"
 
 clojure "${jvm_opts[@]}" -Sdeps "$deps" "$@" -m edge.rebel.main


### PR DESCRIPTION
I think this is the last one 🤞.

* combines all of the elements of the array together in a single
"shell word", whereas @ expands each element of the array into its own
"shell word".

See https://stackoverflow.com/a/3355375 for a good explanation of the
difference between * vs @.

Addresses SC2124: Assigning an array to a string! Assign as array, or
use * instead of @ to concatenate..