### PR TITLE
Add Calva custom cljs repl settings to template

### DIFF
--- a/lib/edge-app-template/resources/clj/new/app.template/.vscode/settings.json
+++ b/lib/edge-app-template/resources/clj/new/app.template/.vscode/settings.json
@@ -1,8 +1,9 @@
 {
     "calva.customCljsRepl": {
-        "name": "Edge CLJS",
-        "startCode": "(do (require 'dev-extras) ((resolve 'dev-extras/cljs-repl)))",
-        "startingRegExp": "\\[Edge\\] Website listening on: [a-zA-Z0-9:/]+",
-        "connectedRegExp": "Prompt will show"
+        "name": "Edge Figwheel Main",
+        "startCode": "(do (require 'dev-extras) (dev-extras/go) (println \"Edge Figwheel Main started\") ((resolve 'dev-extras/cljs-repl)))",
+        "tellUserToStartRegExp": "Edge Figwheel Main started",
+        "printThisLineRegExp": "Website listening on|Open URL",
+        "connectedRegExp": "To quit, type: :cljs/quit"
     }
 }

--- a/lib/edge-app-template/resources/clj/new/app.template/.vscode/settings.json
+++ b/lib/edge-app-template/resources/clj/new/app.template/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "calva.customCljsRepl": {
+        "name": "Edge",
+        "startCode": "(do (require 'dev-extras) ((resolve 'dev-extras/cljs-repl)))",
+        "startingRegExp": "\\[Edge\\] Website listening on: [a-zA-Z0-9:/]+",
+        "connectedRegExp": "Prompt will show"
+    }
+}

--- a/lib/edge-app-template/resources/clj/new/app.template/.vscode/settings.json
+++ b/lib/edge-app-template/resources/clj/new/app.template/.vscode/settings.json
@@ -3,7 +3,7 @@
         "name": "Edge Figwheel Main",
         "startCode": "(do (require 'dev-extras) (dev-extras/go) (println \"Edge Figwheel Main started\") ((resolve 'dev-extras/cljs-repl)))",
         "tellUserToStartRegExp": "Edge Figwheel Main started",
-        "printThisLineRegExp": "Website listening on|Open URL",
+        "printThisLineRegExp": "\\[Edge\\]|Open URL",
         "connectedRegExp": "To quit, type: :cljs/quit"
     }
 }

--- a/lib/edge-app-template/resources/clj/new/app.template/.vscode/settings.json
+++ b/lib/edge-app-template/resources/clj/new/app.template/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "calva.customCljsRepl": {
-        "name": "Edge",
+        "name": "Edge CLJS",
         "startCode": "(do (require 'dev-extras) ((resolve 'dev-extras/cljs-repl)))",
         "startingRegExp": "\\[Edge\\] Website listening on: [a-zA-Z0-9:/]+",
         "connectedRegExp": "Prompt will show"


### PR DESCRIPTION
Supports Calva jack-in for Edge CLJS apps by adding an
`Edge` cljs repl option to the  project type quick-pick menu.

I don't know how to test this so that the template is created from my fork. But I have tested to add the same file to a freshly created `bin/app acme.app --cljs` with good results.