### PR TITLE
Update crux dependency and api call in ::standalone

### DIFF
--- a/lib/crux.ig/deps.edn
+++ b/lib/crux.ig/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps
- {juxt/crux {:mvn/version "19.04-1.0.2-alpha"}
+ {juxt/crux-core {:mvn/version "19.07-1.3.0-alpha"}
   integrant {:mvn/version "0.7.0"}}
  :aliases
  {:dev

--- a/lib/crux.ig/src/juxt/crux/ig/system.clj
+++ b/lib/crux.ig/src/juxt/crux/ig/system.clj
@@ -39,7 +39,7 @@
 
 (defmethod ig/init-key ::standalone
   [_ opts]
-  (crux.api/start-standalone-system opts))
+  (crux.api/start-standalone-node opts))
 
 (derive ::cluster-node :juxt.crux.ig/system)
 


### PR DESCRIPTION
This change prevents `juxt.crux.ig.system` from firing ` No such var: crux.api/start-standalone-system`, when requiring the latest crux version `19.07-1.3.0-alpha`. I noticed the error while I was following the tutorials of the Juxt blog.

Crux commit breaking the API: `980893262073a2ca580b687fc2f7d54619fc4376` 