### PR TITLE
Remove unnecessary bidi dependency

### DIFF
--- a/lib/edge.system/deps.edn
+++ b/lib/edge.system/deps.edn
@@ -1,7 +1,6 @@
 {:paths ["src"],
  :deps
- {bidi/bidi {:mvn/version "2.1.4"},
-  integrant/integrant {:mvn/version "0.7.0"},
+ {integrant/integrant {:mvn/version "0.7.0"},
   aero/aero {:mvn/version "1.1.3"}},
  :aliases
  {:test {:extra-paths ["test"]


### PR DESCRIPTION
This looks like it's redundant. I'm looking to use this module from warp and I want to avoid all bidi/yada dependencies.