### PR TITLE
Add settings for Calva Connect Sequences

### DIFF
--- a/lib/edge-app-template/links/cljs_calva_settings.json
+++ b/lib/edge-app-template/links/cljs_calva_settings.json
@@ -18,8 +18,8 @@
             "projectType": "Clojure CLI",
             "cljsType": {
                 "dependsOn": "Figwheel Main",
-                "startCode": "(do (require 'dev-extras) (dev-extras/go) (println \"Edge Figwheel Main started\"))",
-                "isReadyToStartRegExp": "Edge Figwheel Main started",
+                "startCode": "(do (require 'dev-extras) (dev-extras/go) (println \"System started\"))",
+                "isReadyToStartRegExp": "System started",
                 "openUrlRegExp": "Website listening on: (?<url>\\S+)",
                 "printThisLineRegExp": "\\[Edge\\]",
                 "shouldOpenUrl": true,

--- a/lib/edge-app-template/links/cljs_calva_settings.json
+++ b/lib/edge-app-template/links/cljs_calva_settings.json
@@ -7,5 +7,33 @@
         "tellUserToStartRegExp": "Edge Figwheel Main started",
         "printThisLineRegExp": "\\[Edge\\]|Open URL",
         "connectedRegExp": "To quit, type: :cljs/quit"
-    }
+    },
+    "calva.replConnectSequences": [
+        {
+            "name": "Edge backend only",
+            "projectType": "Clojure CLI"
+        },
+        {
+            "name": "Edge backend + frontend",
+            "projectType": "Clojure CLI",
+            "cljsType": {
+                "dependsOn": "Figwheel Main",
+                "startCode": "(do (require 'dev-extras) (dev-extras/go) (println \"Edge Figwheel Main started\") ((resolve 'dev-extras/cljs-repl)))",
+                "isReadyToStartRegExp": "Edge Figwheel Main started",
+                "openUrlRegExp": "Website listening on: (?<url>\\S+)",
+                "printThisLineRegExp": "\\[Edge\\]",
+                "shouldOpenUrl": true,
+                "connectCode": "(do (require 'dev-extras) ((resolve 'dev-extras/cljs-repl)))",
+                "isConnectedRegExp": "To quit, type: :cljs/quit",
+                "buildsRequired": false
+            },
+            "menuSelections": {
+                "cljAliases": [
+                    "dev",
+                    "build",
+                    "dev/build"
+                ]
+            }
+        }
+    ]
 }

--- a/lib/edge-app-template/links/cljs_calva_settings.json
+++ b/lib/edge-app-template/links/cljs_calva_settings.json
@@ -18,7 +18,7 @@
             "projectType": "Clojure CLI",
             "cljsType": {
                 "dependsOn": "Figwheel Main",
-                "startCode": "(do (require 'dev-extras) (dev-extras/go) (println \"Edge Figwheel Main started\") ((resolve 'dev-extras/cljs-repl)))",
+                "startCode": "(do (require 'dev-extras) (dev-extras/go) (println \"Edge Figwheel Main started\"))",
                 "isReadyToStartRegExp": "Edge Figwheel Main started",
                 "openUrlRegExp": "Website listening on: (?<url>\\S+)",
                 "printThisLineRegExp": "\\[Edge\\]",


### PR DESCRIPTION
This adds setting for the new way to configure custom CLJS REPLs in Calva.

Two sequences are set up:
1. Edge backend + frontend
   * This setting includes all Calva needs to know and doesn't prompt the user about anything else.
   * **NB:** The setting `"shouldOpenUrl": true` makes Calva automatically start the Edge ClojureScript app in the browser, making the Jack-in fully automatic. If you think this is not a desirable default, let me know and I'll update the PR.
1. Edge backend only
   * This setting does not include any presets, so Calva will prompt for some more info during jack-in.

The Calva Jack-in menu looks like so with these settings added:

<img width="603" alt="image" src="https://user-images.githubusercontent.com/30010/65608849-1ec4de00-dfaf-11e9-80a5-58c9f5b365ec.png">

The instructions for using Calva for a freshly created Edge ClojureScript app will be like so:

1. Open the project root directory in VS Code.
1. Open a project file, e.g. `deps.edn`.
1. Jack-in: <kbd>ctrl+alt+c</kbd>,<kbd>ctrl+alt+j</kbd>.
   * Select **Edge backend + frontend**.
   * Wait for the project to start and the two REPL Windows to open: _CLJ REPL_ and _CLJS REPL_.
1. Hack away.