### PR TITLE
Add yada functionality to serve a local system directory or file

### DIFF
--- a/lib/edge.ig.yada/src/edge/yada/ig.clj
+++ b/lib/edge.ig.yada/src/edge/yada/ig.clj
@@ -26,6 +26,16 @@
     id
     (assoc :id id)))
 
+(defmethod ig/init-key ::external-directories
+  [_ {:keys [path options]}]
+  (yada.resources.file-resource/new-directory-resource
+   (io/file path) (or options {})))
+
+(defmethod ig/init-key ::external-files
+  [_ {:keys [path options]}]
+  (yada.resources.file-resource/new-file-resource
+   (io/file path) (or options {})))
+
 (defmethod ig/init-key ::classpath-name
   [_ {:keys [name]}]
   (yada/as-resource (io/resource name)))


### PR DESCRIPTION
# Usage examples: 

## From your `config.edn`:

### Serve directory:
```
...
:ig.system/base
{[:my.project/foo :edge.yada.ig/external-directories]
 {:path "/home/user/target/folder/"
  :options {:custom-suffices [...]
            :index-files [...]
             ...}}
...
```

And in your `edge.bidi.ig/vhost`:
```
["/foo/" #ig/ref [:my.project/foo :edge.yada.ig/external-directories]]
```

### Serve single file:
```
...
:ig.system/base
{[:my.project/foo :edge.yada.ig/external-files]
 {:path "/home/user/target/folder/file.txt"
  :options {:produces [...]
              ...}}
...
```

And in your `edge.bidi.ig/vhost`:
```
["/file" #ig/ref [:my.project/foo :edge.yada.ig/external-files]]
```
