### PR TITLE
prevent StackOverflowError error

### DIFF
--- a/lib/edge.test-utils/src/edge/test/system.clj
+++ b/lib/edge.test-utils/src/edge/test/system.clj
@@ -32,7 +32,7 @@
 
 (defn with-subsystem-fixture
   ([ks]
-   (with-subsystem-fixture default-system))
+   (with-subsystem-fixture default-system ks))
   ([system ks]
    (fn [f]
      (with-system (system) ks


### PR DESCRIPTION
when calling `with-subsystem-fixture`