### PR TITLE
Update cljs_calva_settings.json

### DIFF
--- a/lib/edge-app-template/links/cljs_calva_settings.json
+++ b/lib/edge-app-template/links/cljs_calva_settings.json
@@ -1,17 +1,32 @@
 // This file is a symlink to an Edge-wide file, if you'd like to make a change
 // to only your project, copy it into your project before modifying it.
 {
-    "calva.customCljsRepl": {
-        "name": "Edge Figwheel Main",
-        "startCode": "(do (require 'dev-extras) (dev-extras/go) (println \"Edge Figwheel Main started\") ((resolve 'dev-extras/cljs-repl)))",
-        "tellUserToStartRegExp": "Edge Figwheel Main started",
-        "printThisLineRegExp": "\\[Edge\\]|Open URL",
-        "connectedRegExp": "To quit, type: :cljs/quit"
-    },
+    "calva.customREPLCommandSnippets": [
+        {
+            "name": "Start Edge Development System",
+            "repl": "clj",
+            "ns": "dev",
+            "snippet": "(go)"
+        },
+        {
+            "name": "Reload Clojure Code",
+            "repl": "clj",
+            "ns": "dev",
+            "snippet": "(reset)"
+        }
+    ],
     "calva.replConnectSequences": [
         {
             "name": "Edge backend only",
-            "projectType": "Clojure CLI"
+            "projectType": "Clojure CLI",
+            "cljsType": "none",
+            "menuSelections": {
+                "cljAliases": [
+                    "dev",
+                    "build",
+                    "dev/build"
+                ]
+            }
         },
         {
             "name": "Edge backend + frontend",


### PR DESCRIPTION
These changes are made:

1. `"cljsType": "none"` added to backend only jack-in. **The lack of this is today stopping jack-in in Calva**.
1. Custom commands added for starting the system and reloading the backend code. When the user invokes this in Calva (`ctrl+alt .`) he will get a prompt with the two commands. Given how this works in VS Code, reloading the Clojure code is now this key sequence: `ctrl+alt+. 2 enter`.
1. Old backward compatibility custom cljs setting is now removed.