### PR TITLE
Bump clojure version to 1.10.1

### DIFF
--- a/examples/juxt.crux.demo/deps.edn
+++ b/examples/juxt.crux.demo/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure {:mvn/version "1.10.1"}
   juxt.edge/lib.app {:local/root "../lib/edge.app"}
 
   yada {:mvn/version "1.3.0-alpha7"}

--- a/examples/phonebook-api/deps.edn
+++ b/examples/phonebook-api/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure {:mvn/version "1.10.1"}
   juxt.edge/lib.app {:local/root "../lib/edge.app"}
 
   yada {:mvn/version "1.3.0-alpha7"}

--- a/examples/tutorial.vent/deps.edn
+++ b/examples/tutorial.vent/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure {:mvn/version "1.10.1"}
   juxt.edge/lib.app {:local/root "../lib/edge.app"}
 
   yada {:mvn/version "1.3.0-alpha7"}

--- a/lib/edge-app-template/resources/clj/new/app.template/deps.edn
+++ b/lib/edge-app-template/resources/clj/new/app.template/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure {:mvn/version "1.10.1"}
   juxt.edge/lib.app {:local/root "../lib/edge.app"}{{#web}}
 
   yada {:mvn/version "1.4.0-alpha1"}

--- a/lib/edge.ig.yada/deps.edn
+++ b/lib/edge.ig.yada/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.10.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         yada {:mvn/version "1.2.15"}
         integrant {:mvn/version "0.6.3"}
         juxt.edge/edge.system {:local/root "../edge.system"}}}

--- a/lib/edge.migration/deps.edn
+++ b/lib/edge.migration/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure {:mvn/version "1.10.1"}
   io.dominic/ednup {:git/url "https://github.com/SevereOverfl0w/ednup.git"
                     :sha "87b2734303d815e6209495b9c6a6ee77aa17ab4b"}
   org.clojure/tools.cli {:mvn/version "0.4.1"}

--- a/lib/edge.migration/test/phonebook-api/input/1
+++ b/lib/edge.migration/test/phonebook-api/input/1
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure {:mvn/version "1.10.1"}
   juxt.edge/lib.app {:local/root "../lib.app"}
 
   yada {:mvn/version "1.3.0-alpha7"}

--- a/lib/edge.migration/test/phonebook-api/output.edn
+++ b/lib/edge.migration/test/phonebook-api/output.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure {:mvn/version "1.10.1"}
   juxt.edge/lib.app {:local/root "../lib/edge.app"}
 
   yada {:mvn/version "1.3.0-alpha7"}

--- a/lib/edge.migration/test/tutorial.vent/input/1
+++ b/lib/edge.migration/test/tutorial.vent/input/1
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure {:mvn/version "1.10.1"}
   juxt.edge/lib.app {:local/root "../lib.app"}
 
   yada {:mvn/version "1.3.0-alpha7"}

--- a/lib/edge.migration/test/tutorial.vent/output.edn
+++ b/lib/edge.migration/test/tutorial.vent/output.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure {:mvn/version "1.10.1"}
   juxt.edge/lib.app {:local/root "../lib/edge.app"}
 
   yada {:mvn/version "1.3.0-alpha7"}


### PR DESCRIPTION
The latest stable version is 1.10.1 so it would be nice to use that instead of 1.10.0 :).