### PR TITLE
Add '--application-id' and '--application-version'

### DIFF
--- a/doc/resources/doc/sources/uberjar.adoc
+++ b/doc/resources/doc/sources/uberjar.adoc
@@ -19,7 +19,7 @@ Build a capsule uberjar using this command:
 
 [source,shell]
 ----
-$ ../bin/capsule -m edge.main -e 'target/prod' -A:prod project.jar
+$ ../bin/capsule -m edge.main --application-id 'your-project-name-here' --application-version 'your-project-version-here' -e 'target/prod' -A:prod project.jar
 ----
 
 If you are using clojurescript in your project make sure you run this command first: 


### PR DESCRIPTION
Add '--application-id' and '--application-version' to the '../bin/capsule' sample command line.  Doing so keeps the 'Capsule Cache' correctly organized.  Without doing this multiple Edge applications can interfere with one another when executed.  CAN ANYONE SAY SHARED GLOBAL STATE!!!

Under the "Running the jar" section it might be worth noting that a 'capsule' JAR can be executed thusly:

CAPSULE_CACHE_DIR='/tmp' java -Xmx1G -jar project.jar 

in order to specify to Capsule that its cache should be built in '/tmp', and deleted after execution.